### PR TITLE
Oprava zobrazení obrázku vybraného nápoje u víceřádkového názvu.

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -177,7 +177,7 @@ nav a:hover {
 }
 
 .drink__cup--selected img {
-  display: none;
+  visibility: hidden;
 }
 
 .drink__info {


### PR DESCRIPTION
Když se název nápoje zalomí na dva řádky a příslušný nápoj se objedná, obrázek nápoje se zmenší – protože display:none vyjme původní obrázek z pozicování a obrázek tak přestane v komponentě držet místo.  Když se schová jen pomocí visibility: hidden, místo v komponentě zůstane zabrané a nic se nezmenšuje.